### PR TITLE
Fix Docs CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - SEGFAULT_SIGNALS=all
   matrix:
     - TOXENV=check
-    # - TOXENV=docs
+    - TOXENV=docs
 matrix:
   include:
     # - python: '2.7'

--- a/tests/test_markov.py
+++ b/tests/test_markov.py
@@ -1,7 +1,7 @@
+import glob
 import os
 import re
 import shutil
-import glob
 import unittest
 from unittest.mock import patch
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,16 +4,15 @@
 envlist =
     clean,
     check,
-    {py27,py33,py34,py35,py36,pypy},
+    {py33,py34,py35,py36,pypy},
     report,
     docs
 
 [testenv]
 basepython =
     pypy: {env:TOXPYTHON:pypy}
-    {py27,docs,spell}: {env:TOXPYTHON:python2.7}
     py33: {env:TOXPYTHON:python3.3}
-    py34: {env:TOXPYTHON:python3.4}
+    {py34,docs,spell}: {env:TOXPYTHON:python3.4}
     py35: {env:TOXPYTHON:python3.5}
     py36: {env:TOXPYTHON:python3.6}
     {bootstrap,clean,check,report,coveralls,codecov}: {env:TOXPYTHON:python3}


### PR DESCRIPTION
Fixes #3 This moves the docs build to Py3.4 and also removes py2.7 from build due to Python2.7 issues

Related: #8