### PR TITLE
Add tests for sentence_split method

### DIFF
--- a/tests/test_ia_markov.py
+++ b/tests/test_ia_markov.py
@@ -1,4 +1,3 @@
-
 import ia_markov
 
 

--- a/tests/test_markov.py
+++ b/tests/test_markov.py
@@ -2,9 +2,7 @@ import glob
 import os
 import re
 import unittest
-
 from unittest.mock import patch
-
 from ia_markov import MarkovModel
 
 


### PR DESCRIPTION
Issue: https://github.com/accraze/python-ia-markov/issues/19

Tests completely the method `sentence_split` of class `MarkovModel`.
The called methods `split_into_sentences` and `self._clean_sentences` were mocked and should be test in its contexts. (I suggest to create a new issue for each of those methods)

Now, the coverage of the file `src/ia_markov/markov.py` is in 80% and the lines of `sentence_split` method (lines 33-41) are not more in uncovered code lines ('missing' column)

Here is the new coverage report:
```
Name                        Stmts   Miss Branch BrPart     Cover   Missing
--------------------------------------------------------------------------
src/ia_markov/__init__.py       3      0      0      0   100.00%
src/ia_markov/markov.py        57     10     18      1    80.00%   92, 103-109, 112-113, 50->exit
tests/test_ia_markov.py         3      0      0      0   100.00%
tests/test_markov.py           55     12      8      1    76.19%   15, 18-28, 82, 81->82
--------------------------------------------------------------------------
TOTAL                         118     22     26      2    79.17%
```